### PR TITLE
WebWorkers compatibility

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -1,8 +1,7 @@
 ;(function () {
 
   var
-    object = typeof exports != 'undefined' ? exports
-           : typeof window  != 'undefined' ? window : self, // self is used in WebWorkers where window doesn't exists
+    object = typeof exports != 'undefined' ? exports : this,
     chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=',
     INVALID_CHARACTER_ERR = (function () {
       // fabricate a suitable error object


### PR DESCRIPTION
The window object doesn't exists in webworkers, self must be used instead.
