### PR TITLE
coerce input to string

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -13,17 +13,18 @@
   // [https://gist.github.com/999166] by [https://github.com/nignag]
   object.btoa || (
   object.btoa = function (input) {
+    var str = String(input);
     for (
       // initialize result and counter
       var block, charCode, idx = 0, map = chars, output = '';
-      // if the next input index does not exist:
+      // if the next str index does not exist:
       //   change the mapping table to "="
       //   check if d has no fractional digits
-      input.charAt(idx | 0) || (map = '=', idx % 1);
+      str.charAt(idx | 0) || (map = '=', idx % 1);
       // "8 - idx % 1 * 8" generates the sequence 2, 4, 6, 8
       output += map.charAt(63 & block >> 8 - idx % 1 * 8)
     ) {
-      charCode = input.charCodeAt(idx += 3/4);
+      charCode = str.charCodeAt(idx += 3/4);
       if (charCode > 0xFF) {
         throw new InvalidCharacterError("'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.");
       }
@@ -36,15 +37,15 @@
   // [https://gist.github.com/1020396] by [https://github.com/atk]
   object.atob || (
   object.atob = function (input) {
-    input = input.replace(/=+$/, '');
-    if (input.length % 4 == 1) {
+    var str = String(input).replace(/=+$/, '');
+    if (str.length % 4 == 1) {
       throw new InvalidCharacterError("'atob' failed: The string to be decoded is not correctly encoded.");
     }
     for (
       // initialize result and counters
       var bc = 0, bs, buffer, idx = 0, output = '';
       // get next character
-      buffer = input.charAt(idx++);
+      buffer = str.charAt(idx++);
       // character found in table? initialize bit storage and add its ascii value;
       ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer,
         // and if not first of each 4 characters,

--- a/test/base64.coffee
+++ b/test/base64.coffee
@@ -28,6 +28,11 @@ describe 'Base64.js', ->
       err.name is 'InvalidCharacterError' and
       err.message is "'btoa' failed: The string to be encoded contains characters outside of the Latin1 range."
 
+  it 'coerces input', ->
+    assert.strictEqual btoa(42), btoa('42')
+    assert.strictEqual btoa(null), btoa('null')
+    assert.strictEqual btoa({x: 1}), btoa('[object Object]')
+
   it 'can decode Base64-encoded input', ->
     assert.strictEqual atob(''), ''
     assert.strictEqual atob('Zg=='), 'f'
@@ -50,3 +55,7 @@ describe 'Base64.js', ->
       err instanceof Error and
       err.name is 'InvalidCharacterError' and
       err.message is "'atob' failed: The string to be decoded is not correctly encoded."
+
+  it 'coerces input', ->
+    assert.strictEqual atob(42), atob('42')
+    assert.strictEqual atob(null), atob('null')


### PR DESCRIPTION
Closes #14

Commit message:

> This is arguably undesirable behaviour, but this is what browsers do, and a polyfill should implement the missing feature as faithfully as possible.

In my limited testing, I found one discrepancy between browsers: `btoa(null)` in Safari gives the empty string, whereas other browsers I tried give the same result as `btoa('null')`. Other values (including undefined) _are_ coerced in Safari; apparently only null receives special treatment.
