### PR TITLE
add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "base64",
+  "version": "0.2.1",
+  "description": "Base64 encoding and decoding",
+  "main": "./base64.js",
+  "license": "WTFPL",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/davidchambers/Base64.js.git"
+  },
+  "ignore": [
+    "**/.*",
+    "Makefile",
+    "coverage/",
+    "scripts/",
+    "test/"
+  ]
+}


### PR DESCRIPTION
This package is already available via Bower. Adding **bower.json** will make `bower info base64` more informative, and will prevent the inclusion of unnecessary files.
