### PR TITLE
readme: remove reference to (deprecated) yepnope

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,7 @@
 ≈ 500 byte* polyfill for browsers which don't provide [`window.btoa`][1] and
 [`window.atob`][2].
 
-Although the script does no harm in browsers which do provide these functions,
-a conditional script loader such as [yepnope][3] can prevent unnecessary HTTP
-requests.
-
-```javascript
-yepnope({
-  test: window.btoa && window.atob,
-  nope: 'base64.js',
-  callback: function () {
-    // `btoa` and `atob` are now safe to use
-  }
-})
-```
-
-Base64.js stems from a [gist][4] by [yahiko][5].
+Base64.js stems from a [gist][3] by [yahiko][4].
 
 ### Running the test suite
 
@@ -31,6 +17,5 @@ Base64.js stems from a [gist][4] by [yahiko][5].
 
 [1]: https://developer.mozilla.org/en/DOM/window.btoa
 [2]: https://developer.mozilla.org/en/DOM/window.atob
-[3]: http://yepnopejs.com/
-[4]: https://gist.github.com/229984
-[5]: https://github.com/yahiko
+[3]: https://gist.github.com/229984
+[4]: https://github.com/yahiko


### PR DESCRIPTION
Is it okay to simply remove this section? How are the kids doing feature detection these days?
