### PR TITLE
package.json: remove debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "url": "git://github.com/davidchambers/Base64.js.git"
   },
   "devDependencies": {
-    "debug": "3.2.x",
     "eslint": "5.15.x",
     "istanbul": "0.4.x",
     "mocha": "3.5.x",


### PR DESCRIPTION
This transitive dependency was added as an explicit dependency in #34, but the workaround is no longer necessary as a result of #35.
