### PR TITLE
travis: update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
+  - "6"
+  - "8"
   - "10"
+  - "12"
 install: make setup
 script: make lint test


### PR DESCRIPTION
I have been treating ancient Node versions as proxies for ancient browsers, but if we are to be serious about browser compatibility we should actually run the test suite in browsers. Since this project is rarely modified, configuring and maintaining such infrastructure seems unnecessary.
