### PR TITLE
travis: migrate to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Lint and test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14, 16, 18]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: make setup
+      - run: make lint
+      - run: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - "12.22.0"
-  - "14"
-  - "16"
-install: make setup
-script: make lint test


### PR DESCRIPTION
Travis CI is a source of frustration. Currently it tells me that “[b]uilds have been temporarily disabled for public repositories due to a negative credit balance”. I don't understand this message as I have plenty of credit.

I've been meaning to try GitHub Actions; I now have a compelling reason to do so.
