### PR TITLE
fix: update btoa boundary

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -37,7 +37,7 @@
       o2 = data.charCodeAt (i++);
       o3 = data.charCodeAt (i++);
 
-      if (o1 > 128 || o2 > 128 || o3 > 128) {
+      if (o1 > 255 || o2 > 255 || o3 > 255) {
         throw new InvalidCharacterError ("'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.");
       }
 

--- a/test/base64.js
+++ b/test/base64.js
@@ -29,7 +29,8 @@ describe ('Base64.js', function() {
     assert.strictEqual (btoa ('qrstuvwxyz{|}~'), 'cXJzdHV2d3h5ent8fX4=');
   });
 
-  it ('cannot encode non-ASCII input', function() {
+  it ('cannot encode characters beyond U+00FF', function() {
+    assert.strictEqual (String.fromCharCode (0x2708), '✈');
     assert.throws (
       function() { btoa ('✈'); },
       function(err) {
@@ -81,6 +82,13 @@ describe ('Base64.js', function() {
   it ('coerces input', function() {
     assert.strictEqual (atob (42), atob ('42'));
     assert.strictEqual (atob (null), atob ('null'));
+  });
+
+  it ('can encode every character in [U+0000, U+00FF]', function() {
+    for (var code = 0x0; code <= 0xFF; code += 0x1) {
+      var char = String.fromCharCode (code);
+      assert.strictEqual (atob (btoa (char)), char);
+    }
   });
 
 });


### PR DESCRIPTION
Hi, as the [description of btoa for unicode string](https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings) from MDN, **one byte** is the range of `btoa` accept.

```js
const testString = 'Í'
console.log(testString.charCodeAt())  // 205
console.log(window.btoa('Í')) // zQ==
```