### PR TITLE
package.json: support `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "uglify-js": "3.5.x",
     "xyz": "4.0.x"
   },
+  "scripts": {
+    "test": "make lint test"
+  },
   "files": [
     "/LICENSE",
     "/README.md",


### PR DESCRIPTION
When using a recent version of npm, `npm test` fails if there is no test script defined. This is problematic because xyz runs `npm test` as part of the automated release process.
